### PR TITLE
Link address check in javascript

### DIFF
--- a/site/viewuserdata.php
+++ b/site/viewuserdata.php
@@ -290,8 +290,17 @@ if (!isset($MyPHPScript)) return;
 	// Функция добавления впечатдения
 	function AddLink()
 	{ 
-		document.UserLinksForm.action.value = "AddLink";
-		document.UserLinksForm.submit();
+		if (document.UserLinksForm.NewLinkUrl.value.startsWith('http://')
+		    || document.UserLinksForm.NewLinkUrl.value.startsWith('https://'))
+		    || document.UserLinksForm.LinkTypeId.value === "6"
+		{
+			document.UserLinksForm.action.value = "AddLink";
+			document.UserLinksForm.submit();
+		}
+		else
+		{
+			alert("Поле 'Адрес ссылки' должно содержать адрес, например http://your-site.com/mmb.html");
+		}
 	}
 
 	// Функция добавления впечатдения


### PR DESCRIPTION
People often paste their links into "link text" and not "link address"
or enter invalid links for other reasons. This change disables submitting
links with invalid URLs for linktypes other than backpack weight.